### PR TITLE
fix(#3553):Broken Link for Custom Widgets and Fields in UISchema Page

### DIFF
--- a/packages/docs/docs/api-reference/uiSchema.md
+++ b/packages/docs/docs/api-reference/uiSchema.md
@@ -83,7 +83,7 @@ This will make all widgets have an id prefixed with `myform`.
 The `ui:field` property overrides the `Field` implementation used for rendering any field in the form's hierarchy.
 Specify either the name of a field that is used to look up an implementation from the `fields` list or an actual one-off `Field` component implementation itself.
 
-See [Custom Widgets and Fields](../advanced-customization/custom-widgets-fields#custom-field-components) for more information about how to use this property.
+See [Custom Widgets and Fields](https://rjsf-team.github.io/react-jsonschema-form/docs/advanced-customization/custom-widgets-fields) for more information about how to use this property.
 
 ### ui:fieldReplacesAnyOrOneOf
 


### PR DESCRIPTION
### Reasons for making this change

[Please describe them here]

If this is related to existing tickets, include links to them as well. Use the syntax `fixes #[issue number]` (ex: `fixes #123`).

If your PR is non-trivial and you'd like to schedule a synchronous review, please add it to the weekly meeting agenda: https://docs.google.com/document/d/12PjTvv21k6LIky6bNQVnsplMLLnmEuypTLQF8a-8Wss/edit

### Checklist

- [x] **I'm updating documentation**
  - [x] I've [checked the rendering](https://rjsf-team.github.io/react-jsonschema-form/docs/contributing) of the Markdown text I've added
- [ ] **I'm adding or updating code**
  - [ ] I've added and/or updated tests. I've run `npm run test:update` to update snapshots, if needed.
  - [ ] I've updated [docs](https://rjsf-team.github.io/react-jsonschema-form/docs) if needed
  - [ ] I've updated the [changelog](https://github.com/rjsf-team/react-jsonschema-form/blob/main/CHANGELOG.md) with a description of the PR
- [ ] **I'm adding a new feature**
  - [ ] I've updated the playground with an example use of the feature
